### PR TITLE
Fix how TinyMCE configuration options are rendered in JavaScript

### DIFF
--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -78,9 +78,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         return super(TinyMCERichTextArea, self).render(name, translated_value, attrs)
 
     def render_js_init(self, id_, name, value):
-        kwargs = {
-            'options': self.kwargs.get('options', {}),
-        }
+        kwargs = self.kwargs.get('options', {})
 
         if 'buttons' in self.kwargs:
             if self.kwargs['buttons'] is False:


### PR DESCRIPTION
Currently the options passed to the TinyMCERichTextArea constructor or  the provided default options have no effect.

When the options are rendered into JavaScript, they are nested inside an 'options' object that is passed to the the TinyMCE constructor. This results in them being ignored by TinyMCE. This PR removes the nesting so that each of the individual options are passed to TinyMCE as top-level properties of the configuration object.
