### PR TITLE
Avoid problems with translations in management commands for Django>1.9

### DIFF
--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -56,7 +56,8 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
             'options': {
                 'browser_spellcheck': True,
                 'noneditable_leave_contenteditable': True,
-                'language': translation.to_locale(translation.get_language()),
+                'language': translation.to_locale(translation.get_language()) if \
+                     translation.get_language() else None,
                 'language_load': True,
             },
         }


### PR DESCRIPTION
Django stopped returning languages in management commands as of Django 1.8 (https://docs.djangoproject.com/en/1.9/howto/custom-management-commands/#management-commands-and-locales).
