### PR TITLE
Make classes survive link manipulation by wagtaillink plugin

### DIFF
--- a/wagtailtinymce/static/wagtailtinymce/js/tinymce-plugins/wagtaillink.js
+++ b/wagtailtinymce/static/wagtailtinymce/js/tinymce-plugins/wagtaillink.js
@@ -91,6 +91,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                         // select and replace text-only target
                         insertElement = function(elem) {
                             mceSelection.select($targetNode.get(0));
+                            // bring over any classes present
+                            if ($targetNode.attr('class')) {
+                                elem.setAttribute('class', $targetNode.attr('class'));
+                            }
                             mceSelection.setNode(elem);
                         };
                     }


### PR DESCRIPTION
Hi, I found this functionality would be helpful in the case of a text link having some extra styling, like a Bootstrap button class.
