### PR TITLE
Add construct_whitelister_element_rules for TinyMCE.

### DIFF
--- a/wagtailtinymce/wagtail_hooks.py
+++ b/wagtailtinymce/wagtail_hooks.py
@@ -36,6 +36,7 @@ from django.utils.safestring import mark_safe
 
 from wagtail.wagtailadmin.templatetags.wagtailadmin_tags import hook_output
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.whitelist import attribute_rule, allow_without_attributes
 
 
 def to_js_primitive(string):
@@ -132,3 +133,50 @@ def docs_richtexteditor_js():
         to_js_primitive(static('wagtailtinymce/js/tinymce-plugins/wagtaildoclink.js')),
         to_js_primitive(translation.to_locale(translation.get_language())),
     )
+
+
+@hooks.register('construct_whitelister_element_rules')
+def whitelister_element_rules():
+    common = {
+        'style': True,
+        'width': True,
+        'margin-left': True,
+        'margin-right': True,
+        'height': True,
+        'border-color': True,
+        'text-align': True,
+        'background-color': True,
+        'vertical-align': True,
+        'font-family': True,
+        'valign': True,
+    }
+
+    table_rule = attribute_rule(dict(common, **{
+        'border': True,
+        'cellpadding': True,
+        'cellspacing': True,
+    }))
+    row_rule = attribute_rule(common)
+    cell_rule = attribute_rule(dict(common, **{
+        'colspan': True,
+        'scope': True,
+        'rowspan': True,
+    }))
+
+    return {
+        'blockquote': allow_without_attributes,
+        'pre': allow_without_attributes,
+        'span': allow_without_attributes,
+        'code': allow_without_attributes,
+
+        'table': table_rule,
+        'thead': allow_without_attributes,
+        'tfoot': allow_without_attributes,
+        'tbody': allow_without_attributes,
+        'colgroup': allow_without_attributes,
+        'col': allow_without_attributes,
+        'caption': allow_without_attributes,
+        'tr': row_rule,
+        'th': cell_rule,
+        'td': cell_rule,
+    }


### PR DESCRIPTION
Wagtail cleans the rich text HTML so will remove any HTML produced by TinyMCE that is not whitelisted.

This PR adds support for the default TinyMCE setup using wagtail's [construct-whitelister-element-rules](http://docs.wagtail.io/en/v1.9/reference/hooks.html?highlight=attribute_rule#construct-whitelister-element-rules) - related to https://github.com/isotoma/wagtailtinymce/pull/6/files#r109283251

