### PR TITLE
Fix static issue in production

### DIFF
--- a/wagtailtinymce/wagtail_hooks.py
+++ b/wagtailtinymce/wagtail_hooks.py
@@ -26,6 +26,8 @@
 
 import json
 
+from django.conf import settings
+
 from django.core.urlresolvers import reverse
 from django.templatetags.static import static
 from django.utils import translation
@@ -66,7 +68,7 @@ def insert_editor_js():
         '    window.tinymce.suffix = "";'
         '}}());'
         '</script>',
-        to_js_primitive(static('wagtailtinymce/js/vendor/tinymce')),
+        to_js_primitive(settings.STATIC_URL + 'wagtailtinymce/js/vendor/tinymce'),
     )
     js_files = [
         'wagtailtinymce/js/vendor/tinymce/tinymce.jquery.js',


### PR DESCRIPTION
Static file storage fails in production at the `insert_editor_js` function when using the `static` template tag:

`Exception Value: Missing staticfiles manifest entry for 'wagtailtinymce/js/vendor/tinymce'

Added Django settings import to use `STATIC_URL` instead, as this is only a base URL reference for JS.