### PR TITLE
Wagtail 2.0 & Django 2.0 support

### DIFF
--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -31,9 +31,9 @@ from django.forms import widgets
 from django.utils import translation
 from wagtail.utils.widgets import WidgetWithScript
 
-from wagtail import __version__
+from wagtail import __version__ as WAGTAIL_VERSION
 
-if __version__ >= '2.0':
+if WAGTAIL_VERSION >= '2.0':
     from wagtail.admin.edit_handlers import RichTextFieldPanel
     from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
     from wagtail.core.rich_text import features
@@ -76,7 +76,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         if kwargs is not None:
             self.kwargs.update(kwargs)
 
-        if __version__ >= '2.0':
+        if WAGTAIL_VERSION >= '2.0':
             if self.features is None:
                 self.features = features.get_default_features()
                 self.converter = EditorHTMLConverter()
@@ -90,7 +90,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         if value is None:
             translated_value = None
         else:
-            if __version__ >= '2.0':
+            if WAGTAIL_VERSION >= '2.0':
                 translated_value = self.converter.from_database_format(value)
             else:
                 translated_value = expand_db_html(value, for_editor=True)
@@ -123,7 +123,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         if original_value is None:
             return None
 
-        if __version__ >= '2.0':
+        if WAGTAIL_VERSION >= '2.0':
             return self.converter.to_database_format(original_value)
         else:
             return DbWhitelister.clean(original_value)

--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -35,8 +35,8 @@ from wagtail import __version__
 
 if __version__ >= '2.0':
     from wagtail.admin.edit_handlers import RichTextFieldPanel
-    from wagtail.admin.rich_text.converters.editor_html import DbWhitelister
-    from wagtail.core.rich_text import expand_db_html
+    from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
+    from wagtail.core.rich_text import features
 else:
     from wagtail.wagtailadmin.edit_handlers import RichTextFieldPanel
     from wagtail.wagtailcore.rich_text import DbWhitelister
@@ -72,8 +72,16 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
     def __init__(self, attrs=None, **kwargs):
         super(TinyMCERichTextArea, self).__init__(attrs)
         self.kwargs = self.getDefaultArgs()
+        self.features = kwargs.pop('features', None)
         if kwargs is not None:
             self.kwargs.update(kwargs)
+
+        if __version__ >= '2.0':
+            if self.features is None:
+                self.features = features.get_default_features()
+                self.converter = EditorHTMLConverter()
+            else:
+                self.converter = EditorHTMLConverter(self.features)
 
     def get_panel(self):
         return RichTextFieldPanel
@@ -82,7 +90,10 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         if value is None:
             translated_value = None
         else:
-            translated_value = expand_db_html(value, for_editor=True)
+            if __version__ >= '2.0':
+                translated_value = self.converter.from_database_format(value)
+            else:
+                translated_value = expand_db_html(value, for_editor=True)
         return super(TinyMCERichTextArea, self).render(name, translated_value, attrs)
 
     def render_js_init(self, id_, name, value):
@@ -111,4 +122,8 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         original_value = super(TinyMCERichTextArea, self).value_from_datadict(data, files, name)
         if original_value is None:
             return None
-        return DbWhitelister.clean(original_value)
+
+        if __version__ >= '2.0':
+            return self.converter.to_database_format(original_value)
+        else:
+            return DbWhitelister.clean(original_value)

--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -30,9 +30,17 @@ import json
 from django.forms import widgets
 from django.utils import translation
 from wagtail.utils.widgets import WidgetWithScript
-from wagtail.wagtailadmin.edit_handlers import RichTextFieldPanel
-from wagtail.wagtailcore.rich_text import DbWhitelister
-from wagtail.wagtailcore.rich_text import expand_db_html
+
+from wagtail import __version__
+
+if __version__ >= '2.0':
+    from wagtail.admin.edit_handlers import RichTextFieldPanel
+    from wagtail.admin.rich_text.converters.editor_html import DbWhitelister
+    from wagtail.core.rich_text import expand_db_html
+else:
+    from wagtail.wagtailadmin.edit_handlers import RichTextFieldPanel
+    from wagtail.wagtailcore.rich_text import DbWhitelister
+    from wagtail.wagtailcore.rich_text import expand_db_html
 
 
 class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):

--- a/wagtailtinymce/wagtail_hooks.py
+++ b/wagtailtinymce/wagtail_hooks.py
@@ -26,7 +26,7 @@
 
 import json
 
-from django.core.urlresolvers import reverse
+from django import __version__ as DJANGO_VERSION
 from django.templatetags.static import static
 from django.utils import translation
 from django.utils.html import escape
@@ -34,9 +34,14 @@ from django.utils.html import format_html
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 
-from wagtail import __version__
+from wagtail import __version__ as WAGTAIL_VERSION
 
-if __version__ >= '2.0':
+if DJANGO_VERSION >= '2.0':
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
+
+if WAGTAIL_VERSION >= '2.0':
     from wagtail.admin.templatetags.wagtailadmin_tags import hook_output
     from wagtail.core import hooks
 else:

--- a/wagtailtinymce/wagtail_hooks.py
+++ b/wagtailtinymce/wagtail_hooks.py
@@ -34,8 +34,14 @@ from django.utils.html import format_html
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 
-from wagtail.wagtailadmin.templatetags.wagtailadmin_tags import hook_output
-from wagtail.wagtailcore import hooks
+from wagtail import __version__
+
+if __version__ >= '2.0':
+    from wagtail.admin.templatetags.wagtailadmin_tags import hook_output
+    from wagtail.core import hooks
+else:
+    from wagtail.wagtailadmin.templatetags.wagtailadmin_tags import hook_output
+    from wagtail.wagtailcore import hooks
 
 
 def to_js_primitive(string):


### PR DESCRIPTION
This PR adds support Wagtail 2.0 & Django 2.0 support  to WagtailTinyMCE whilst maintaining backwards compatibility to older Wagtail & Django versions versions.

- Updates module paths to match new Wagtail structure
- Updates `TinyMCERichTextArea` to use new `EditorHTMLConverter` for `render` and `value_from_dict`.  Followed example use within wagtail: https://github.com/wagtail/wagtail/blob/3e1ab7e74f5b182b8f591d5b1ed2dc0f556812e2/wagtail/admin/rich_text/__init__.py#L81
- Use `django.urls` instead of `django.core.urlresolvers`
